### PR TITLE
feat: weather widget heat-danger and rain-emphasis indicators

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -50,7 +50,7 @@ async def get_live_weather():
         "latitude": PFLUGERVILLE_COORDS["lat"],
         "longitude": PFLUGERVILLE_COORDS["lon"],
         "current_weather": True,
-        "daily": ["weathercode", "temperature_2m_max", "temperature_2m_min", "precipitation_probability_max"],
+        "daily": ["weathercode", "temperature_2m_max", "temperature_2m_min", "precipitation_probability_max", "apparent_temperature_max", "apparent_temperature_min"],
         "temperature_unit": "fahrenheit",
         "timezone": "auto"
     }
@@ -74,7 +74,10 @@ async def get_live_weather():
                     "icon": current_info["icon"],
                     "high": f"{round(daily['temperature_2m_max'][0])}°",
                     "low": f"{round(daily['temperature_2m_min'][0])}°",
-                    "rain_prob": f"{prob_today}%"
+                    "rain_prob": f"{prob_today}%",
+                    "rain_prob_val": prob_today,
+                    "feels_like": f"{round(daily['apparent_temperature_max'][0])}°",
+                    "is_hot": daily['temperature_2m_max'][0] > 90
                 },
                 "forecast": []
             }
@@ -94,7 +97,9 @@ async def get_live_weather():
                     "day": day_name,
                     "temp": f"{round(daily['temperature_2m_max'][i])}°",
                     "icon": icon,
-                    "prob": f"{f_prob}%"
+                    "prob": f"{f_prob}%",
+                    "rain_prob_val": f_prob,
+                    "is_hot": daily['temperature_2m_max'][i] > 90
                 })
 
             weather_cache["data"] = weather_data
@@ -102,7 +107,7 @@ async def get_live_weather():
             return weather_data
     except Exception:
         return {
-            "current": {"temp": "--", "condition": "Offline", "icon": "fa-exclamation-triangle", "high": "--", "low": "--", "rain_prob": "0%"},
+            "current": {"temp": "--", "condition": "Offline", "icon": "fa-exclamation-triangle", "high": "--", "low": "--", "rain_prob": "0%", "rain_prob_val": 0, "feels_like": "--", "is_hot": False},
             "forecast": []
         }
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -196,26 +196,39 @@
             <div class="bg-white/5 rounded-[2rem] p-4 border border-white/5 shadow-lg">
                 <div class="flex items-center justify-between mb-2">
                     <div class="flex items-center gap-4">
-                        <i class="fas {{ weather.current.icon }} text-3xl text-amber-500"></i>
+                        <i class="fas {{ weather.current.icon }} text-3xl {% if weather.current.is_hot | default(false) %}text-red-500{% else %}text-amber-500{% endif %}"></i>
                         <div>
-                            <div class="text-3xl font-bold tracking-tighter">{{ weather.current.temp }}</div>
+                            <div class="text-3xl font-bold tracking-tighter {% if weather.current.is_hot | default(false) %}text-red-500{% else %}text-white{% endif %}">{{ weather.current.temp }}</div>
+                            {% if (weather.current.feels_like | default(weather.current.temp)) != weather.current.temp %}
+                            <div class="text-[0.6rem] text-slate-500 font-bold uppercase tracking-wider mt-0.5">Feels: {{ weather.current.feels_like }}</div>
+                            {% else %}
                             <div class="text-slate-400 text-[0.6rem] font-bold uppercase tracking-widest mt-0.5">{{ weather.current.condition }}</div>
+                            {% endif %}
                         </div>
                     </div>
                     <div class="text-right text-[0.6rem] font-black text-slate-400 uppercase leading-none space-y-1.5">
                         <div class="text-slate-200">High: {{ weather.current.high }}</div>
                         <div>Low: {{ weather.current.low }}</div>
-                        <div class="text-blue-400 text-[0.55rem] pt-0.5">
-                            <i class="fas fa-droplet mr-0.5 opacity-50"></i>Rain: {{ weather.current.rain_prob }}
+                        <div class="pt-0.5 {% if (weather.current.rain_prob_val | default(0)) >= 70 %}text-blue-400 text-xs font-bold{% elif (weather.current.rain_prob_val | default(0)) >= 40 %}text-blue-400/90 text-[0.6rem] font-semibold{% elif (weather.current.rain_prob_val | default(0)) >= 20 %}text-blue-400/75 text-[0.55rem] font-medium{% else %}text-slate-500/60 text-[0.55rem]{% endif %}">
+                            <i class="fas fa-droplet mr-0.5 {% if (weather.current.rain_prob_val | default(0)) >= 50 %}opacity-100{% else %}opacity-50{% endif %}"></i>Rain: {{ weather.current.rain_prob }}
                         </div>
                     </div>
                 </div>
                 <div class="grid grid-cols-5 gap-2 pt-3 border-t border-white/10">
                     {% for day in weather.forecast %}
-                    <div class="text-center group">
+                    <div class="text-center group rounded-xl p-1 transition-all
+                                {% if day.is_hot | default(false) %} bg-red-500/10 border border-red-500/10
+                                {% elif (day.rain_prob_val | default(0)) >= 20 %} bg-blue-500/10 border border-blue-500/10
+                                {% else %} border border-transparent {% endif %}">
                         <div class="text-[0.45rem] font-black text-slate-600 uppercase mb-1 tracking-widest">{{ day.day }}</div>
-                        <i class="fas {{ day.icon }} text-amber-500/80 text-lg mb-1"></i>
-                        <div class="text-sm font-bold text-slate-300 leading-none">{{ day.temp }}</div>
+                        <i class="fas {{ day.icon }} {% if day.is_hot | default(false) %} text-red-500 {% else %} text-amber-500/80 {% endif %} text-lg mb-1"></i>
+                        <div class="text-sm font-bold {% if day.is_hot | default(false) %} text-red-400 {% else %} text-slate-300 {% endif %} leading-none">{{ day.temp }}</div>
+                        {% if (day.rain_prob_val | default(0)) >= 20 %}
+                        <div class="text-[0.55rem] text-blue-400 font-bold mt-1 flex items-center justify-center gap-0.5">
+                            <i class="fas fa-droplet text-[0.5rem]"></i>
+                            <span>{{ day.prob }}</span>
+                        </div>
+                        {% endif %}
                     </div>
                     {% endfor %}
                 </div>
@@ -265,74 +278,54 @@
                     Discussion Topics
                 </h3>
                 <div class="flex-1 flex flex-col justify-between gap-1">
-                    <!-- 1. Morning Routine -->
+                    <!-- 1. Daily Routine -->
                     <div class="pb-1">
                         <div class="flex items-center gap-1.5 text-white font-semibold text-base mb-0.5">
                             <i class="fas fa-sun text-amber-500 text-sm w-4 text-center"></i>
-                            <span>Morning Routine</span>
+                            <span>Daily Routine</span>
                         </div>
-                        <ul class="text-slate-400 text-sm pl-4 list-disc space-y-0.5">
+                        <ul class="text-slate-400 text-base pl-4 list-disc space-y-0.5">
                             <li>Feeding schedule and quirks around meals</li>
                             <li>Morning energy level: raring to go or slow starter?</li>
-                        </ul>
-                    </div>
-
-                    <!-- 2. Throughout the Day -->
-                    <div class="pb-1">
-                        <div class="flex items-center gap-1.5 text-white font-semibold text-base mb-0.5">
-                            <i class="fas fa-clock text-amber-500 text-sm w-4 text-center"></i>
-                            <span>Throughout the Day</span>
-                        </div>
-                        <ul class="text-slate-400 text-sm pl-4 list-disc space-y-0.5">
                             <li>Potty frequency and signals they need to go out</li>
                             <li>Play style and how they self-entertain</li>
                         </ul>
                     </div>
 
-                    <!-- 3. Out & About -->
+                    <!-- 2. Out & About -->
                     <div class="pb-1">
                         <div class="flex items-center gap-1.5 text-white font-semibold text-base mb-0.5">
                             <i class="fas fa-route text-amber-500 text-sm w-4 text-center"></i>
                             <span>Out & About</span>
                         </div>
-                        <ul class="text-slate-400 text-sm pl-4 list-disc space-y-0.5">
+                        <ul class="text-slate-400 text-base pl-4 list-disc space-y-0.5">
                             <li>Leash behavior: puller or loose?</li>
                             <li>Reactions to other dogs, strangers, runners, cyclists</li>
                             <li>Ellie and I average 3-4 miles of walking daily and are working toward 8 miles/day cycling; does your pup fit an active pace?</li>
                         </ul>
                     </div>
 
-                    <!-- 4. Personality & Quirks -->
+                    <!-- 3. Personality & Alone Time -->
                     <div class="pb-1">
                         <div class="flex items-center gap-1.5 text-white font-semibold text-base mb-0.5">
                             <i class="fas fa-brain text-amber-500 text-sm w-4 text-center"></i>
-                            <span>Personality & Quirks</span>
+                            <span>Personality & Alone Time</span>
                         </div>
-                        <ul class="text-slate-400 text-sm pl-4 list-disc space-y-0.5">
+                        <ul class="text-slate-400 text-base pl-4 list-disc space-y-0.5">
                             <li>Spooky things: nervous triggers, loud noises</li>
                             <li>Friendliness with new people and dogs</li>
-                        </ul>
-                    </div>
-
-                    <!-- 5. Alone Time -->
-                    <div class="pb-1">
-                        <div class="flex items-center gap-1.5 text-white font-semibold text-base mb-0.5">
-                            <i class="fas fa-house-user text-amber-500 text-sm w-4 text-center"></i>
-                            <span>Alone Time</span>
-                        </div>
-                        <ul class="text-slate-400 text-sm pl-4 list-disc space-y-0.5">
                             <li>A backyard potty break always happens before leaving, out no longer than 1.5 hours</li>
                             <li>Crated or loose when home alone? Any anxiety signals?</li>
                         </ul>
                     </div>
 
-                    <!-- 6. Bedtime -->
+                    <!-- 4. Bedtime -->
                     <div class="pb-0">
                         <div class="flex items-center gap-1.5 text-white font-semibold text-base mb-0.5">
                             <i class="fas fa-moon text-amber-500 text-sm w-4 text-center"></i>
                             <span>Bedtime</span>
                         </div>
-                        <ul class="text-slate-400 text-sm pl-4 list-disc space-y-0.5">
+                        <ul class="text-slate-400 text-base pl-4 list-disc space-y-0.5">
                             <li>Preferred sleep spots and nightly routine</li>
                             <li>Crate comfort and typical duration</li>
                             <li>Bring a familiar scent from home: a blanket or shirt helps them settle in</li>


### PR DESCRIPTION
## Summary
This Pull Request enhances the weather widget in the Wallboard app with heat-danger and rain-emphasis visual indicators, and consolidates the Discussion Topics card for readability.

## What Changed
- In `src/main.py`, updated `get_live_weather` to request apparent_temperature_max and apparent_temperature_min from Open-Meteo.
- Exposed feels_like, is_hot, and rain_prob_val fields to the current weather dictionary, and is_hot and rain_prob_val to forecast list days.
- In `src/templates/index.html`, added conditional styling to render the temperature text and icon in red when `is_hot` is true.
- Subtly render "Feels like" subtitle if feels-like temperature differs from actual temperature.
- Dynamically scale the rain probability visual weight based on the probability value.
- Highlight hot days in the 5-day forecast strip with a subtle red-tinted background, red text, and red icon. Highlight days with meaningful rain probability (>= 20%) with a subtle blue-tinted background and a visible droplet indicator.
- Used Jinja `default()` filters to ensure template robustness.
- Consolidated the Discussion Topics card from six sections down to four, regrouping all original bullets, and increased bullet text size from `text-sm` to `text-base` for improved readability.

## Verification
- Verified server home page loads successfully (`200 OK`).
- Verified visually that there are no template compile errors.
- Checked that no em dashes are used in any of the written prose.
- Tier 1 (manual verification) was applied since no automated test cases are present.

## References
Ref #41
Ref #40
