### PR TITLE
refactor: standardize card title and text hierarchy

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -194,6 +194,10 @@
         <!-- COLUMN 2: ENVIRONMENT & SCHEDULE -->
         <div class="col-span-4 flex flex-col gap-3 h-full">
             <div class="bg-white/5 rounded-[2rem] p-4 border border-white/5 shadow-lg">
+                <h3 class="text-lg font-bold mb-4 flex items-center gap-3 tracking-tight text-white/90">
+                    <i class="fas fa-cloud-sun text-amber-500 text-sm"></i>
+                    Pflugerville Now
+                </h3>
                 <div class="flex items-center justify-between mb-2">
                     <div class="flex items-center gap-4">
                         <i class="fas {{ weather.current.icon }} text-3xl {% if weather.current.is_hot | default(false) %}text-red-500{% else %}text-amber-500{% endif %}"></i>
@@ -247,8 +251,8 @@
                         </div>
                         <div class="flex-1">
                             <div class="flex justify-between items-baseline">
-                                <div class="text-white text-2xl font-semibold group-hover:text-amber-400 leading-none transition-colors">{{ item.activity }}</div>
-                                <div class="text-amber-500 font-black text-lg uppercase tracking-tight pl-3 tabular-nums">{{ item.time }}</div>
+                                <div class="text-white text-base font-semibold group-hover:text-amber-400 leading-none transition-colors">{{ item.activity }}</div>
+                                <div class="text-amber-500 font-black text-sm uppercase tracking-tight pl-3 tabular-nums">{{ item.time }}</div>
                             </div>
                             <div class="h-[1px] w-full bg-slate-800/50 mt-2"></div>
                         </div>


### PR DESCRIPTION
## Summary
This Pull Request standardizes card titles and typography hierarchy across the Wallboard app.

## What Changed
- Added a card title "Pflugerville Now" to the Weather widget card at `text-lg font-bold` with its weather icon at `text-sm` (gap-3), matching the other card titles.
- In the Daily Rhythm card, reduced the activity title from `text-2xl` to `text-base` and the time display from `text-lg` to `text-sm` to conform to the text hierarchy standard.
- Left the Welcome card pup name, Your Host name, and Medical Guardian layout completely untouched.

## Verification
- Checked the local FastAPI server home page response (`200 OK`).
- Verified visually that there are no syntax or layout template errors.
- Checked that no em dashes are used in any of the written prose.
- Tier 1 (manual verification) was applied since no automated test cases are present.

## References
Ref #43
