### PR TITLE
feat: Add sunrise/sunset details next to clock and update Alone Time topics. Ref #48

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -50,7 +50,7 @@ async def get_live_weather():
         "latitude": PFLUGERVILLE_COORDS["lat"],
         "longitude": PFLUGERVILLE_COORDS["lon"],
         "current_weather": True,
-        "daily": ["weathercode", "temperature_2m_max", "temperature_2m_min", "precipitation_probability_max", "apparent_temperature_max", "apparent_temperature_min"],
+        "daily": ["weathercode", "temperature_2m_max", "temperature_2m_min", "precipitation_probability_max", "apparent_temperature_max", "apparent_temperature_min", "sunrise", "sunset"],
         "temperature_unit": "fahrenheit",
         "timezone": "auto"
     }
@@ -67,6 +67,21 @@ async def get_live_weather():
             if w_code >= 51 and prob_today < 20:
                  current_info = {"condition": "Partly Cloudy", "icon": "fa-cloud-sun"}
 
+            sunrise_str = "--"
+            sunset_str = "--"
+            if "sunrise" in daily and len(daily["sunrise"]) > 0:
+                try:
+                    sunrise_dt = datetime.strptime(daily["sunrise"][0], "%Y-%m-%dT%H:%M")
+                    sunrise_str = sunrise_dt.strftime("%-I:%M %p")
+                except Exception:
+                    pass
+            if "sunset" in daily and len(daily["sunset"]) > 0:
+                try:
+                    sunset_dt = datetime.strptime(daily["sunset"][0], "%Y-%m-%dT%H:%M")
+                    sunset_str = sunset_dt.strftime("%-I:%M %p")
+                except Exception:
+                    pass
+
             weather_data = {
                 "current": {
                     "temp": f"{round(current['temperature'])}°",
@@ -77,7 +92,9 @@ async def get_live_weather():
                     "rain_prob": f"{prob_today}%",
                     "rain_prob_val": prob_today,
                     "feels_like": f"{round(daily['apparent_temperature_max'][0])}°",
-                    "is_hot": daily['temperature_2m_max'][0] > 90
+                    "is_hot": daily['temperature_2m_max'][0] > 90,
+                    "sunrise": sunrise_str,
+                    "sunset": sunset_str
                 },
                 "forecast": []
             }
@@ -107,7 +124,7 @@ async def get_live_weather():
             return weather_data
     except Exception:
         return {
-            "current": {"temp": "--", "condition": "Offline", "icon": "fa-exclamation-triangle", "high": "--", "low": "--", "rain_prob": "0%", "rain_prob_val": 0, "feels_like": "--", "is_hot": False},
+            "current": {"temp": "--", "condition": "Offline", "icon": "fa-exclamation-triangle", "high": "--", "low": "--", "rain_prob": "0%", "rain_prob_val": 0, "feels_like": "--", "is_hot": False, "sunrise": "--", "sunset": "--"},
             "forecast": []
         }
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -89,12 +89,23 @@
             
             <div class="flex items-start justify-between px-2">
                 <div class="space-y-1 text-left">
-                    <div class="flex items-baseline gap-2">
+                    <div class="flex items-center gap-4">
                         <div class="text-5xl font-light tracking-tighter text-white uppercase flex items-center gap-0">
                             <span id="clock-hours" class="tabular-nums">--</span>
                             <span class="animate-blink px-1 text-white opacity-100" style="margin-top: -0.1em;">:</span>
                             <span id="clock-mins" class="tabular-nums">--</span>
                             <span id="clock-ampm" class="text-xl opacity-40 ml-2 font-bold">--</span>
+                        </div>
+                        <div class="h-8 w-[1px] bg-white/10"></div>
+                        <div class="flex flex-col justify-center text-[0.55rem] font-bold text-slate-500 uppercase tracking-widest leading-normal">
+                            <div class="flex items-center gap-1">
+                                <i class="fas fa-sun text-amber-500/70 text-[0.65rem] w-3.5 text-center"></i>
+                                <span>{{ weather.current.sunrise | default('--') }}</span>
+                            </div>
+                            <div class="flex items-center gap-1">
+                                <i class="fas fa-moon text-indigo-400/70 text-[0.65rem] w-3.5 text-center"></i>
+                                <span>{{ weather.current.sunset | default('--') }}</span>
+                            </div>
                         </div>
                     </div>
                     <div class="flex items-center gap-2">
@@ -222,7 +233,7 @@
                 </div>
                 <div class="grid grid-cols-5 gap-2 pt-3 border-t border-white/10">
                     {% for day in weather.forecast %}
-                    <div class="text-center group rounded-xl py-3 px-1 transition-all
+                    <div class="text-center group rounded-xl py-4 px-1 transition-all
                                 {% if day.is_hot | default(false) %} bg-red-500/10 border border-red-500/10
                                 {% elif (day.rain_prob_val | default(0)) >= 20 %} bg-blue-500/10 border border-blue-500/10
                                 {% else %} border border-transparent {% endif %}">
@@ -245,7 +256,7 @@
                     <i class="fas fa-calendar-day text-amber-500 text-sm"></i>
                     Daily Rhythm
                 </h3>
-                <div class="space-y-6 relative pr-2">
+                <div class="space-y-8 relative pr-2">
                     {% for item in schedule %}
                     <div class="flex items-center gap-6 group">
                         <div class="z-10 w-10 h-10 rounded-xl glass border-amber-500/20 flex items-center justify-center text-xl shadow-lg">
@@ -306,8 +317,7 @@
                         </div>
                         <ul class="text-slate-400 text-base pl-4 list-disc space-y-0.5">
                             <li>Leash behavior: puller or loose?</li>
-                            <li>Reactions to other dogs, strangers, runners, cyclists</li>
-                            <li>Ellie and I average 3-4 miles of walking daily and are working toward 8 miles/day cycling; does your pup fit an active pace?</li>
+                            <li>Reactions to other dogs, strangers, runners, and cyclists</li>
                         </ul>
                     </div>
 
@@ -320,8 +330,9 @@
                         <ul class="text-slate-400 text-base pl-4 list-disc space-y-0.5">
                             <li>Spooky things: nervous triggers, loud noises</li>
                             <li>Friendliness with new people and dogs</li>
-                            <li>A backyard potty break always happens before leaving, out no longer than 1.5 hours</li>
-                            <li>Crated or loose when home alone? Any anxiety signals?</li>
+                            <li>I run dog walking and drop-in visits for other regular clients: Bella on Tuesdays, Eevee and Tina for drop-ins, and Luke and Leia on Thursdays and Saturdays</li>
+                            <li>These visits typically run 1 to 1.5 hours, so your pup may be alone for that stretch</li>
+                            <li>How do you feel about this? Crated or free roam while I'm out? Any anxiety signals to watch for?</li>
                         </ul>
                     </div>
 


### PR DESCRIPTION
## Summary
This PR relocates the sunrise and sunset display next to the digital clock in Column 1, reverts the Weather card's metrics block to its original state, and updates the Discussion Topics lists to improve content layout and visual balance.

## What Changed
- **Clock Sunrise/Sunset Details**: Stacked sunrise and sunset times vertically to the right of the digital clock numbers in Column 1, separated by a vertical divider.
- **Weather Card Metrics Reverted**: Reverted the Pflugerville Weather card's upper-right metrics block back to its original layout.
- **Weather Forecast Padding**: Increased vertical padding of each forecast day cell from py-3 px-1 to py-4 px-1.
- **Daily Rhythm Row Spacing**: Increased row spacing from space-y-6 to space-y-8 to balance Column 2's total height.
- **Discussion Topics Cleanups**:
  - Removed the cycling activity bullet under Out & About.
  - Replaced the backyard potty break and crated/loose bullets under Personality & Alone Time with three detailed bullets outlining client visits, duration of absences, and dog anxiety/confinement preferences.

## Verification
Verification Tier: Tier 1 (Manual verification).
Restarted the Wallboard service locally and verified that the page renders correctly with HTTP 200 OK status.

## References
Ref #48
