### PR TITLE
fix: set fixed height for welcome card pup photo container. Ref #54

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -52,6 +52,7 @@
         .pup-image-container {
             position: relative;
             width: 100%;
+            height: 280px;
             border-radius: 1.5rem;
             overflow: hidden;
             border: 1px solid rgba(245, 158, 11, 0.2);
@@ -167,13 +168,13 @@
                     </div>
                 </div>
 
-                <div class="relative mx-auto w-full flex-1 min-h-0 flex flex-col">
+                <div class="relative mx-auto w-full flex-1 min-h-0 flex flex-col justify-center">
                     {% if pup_image %}
-                    <div class="pup-image-container shadow-2xl flex-1 min-h-0">
+                    <div class="pup-image-container shadow-2xl">
                         <img src="{{ pup_image }}" alt="{{ pup_name }}">
                     </div>
                     {% else %}
-                    <div class="pup-image-container bg-slate-800/50 flex items-center justify-center border-dashed border-slate-700 flex-1 min-h-0">
+                    <div class="pup-image-container bg-slate-800/50 flex items-center justify-center border-dashed border-slate-700">
                         <div class="text-center p-4">
                             <i class="fas fa-camera text-slate-600 text-4xl mb-2"></i>
                             <p class="text-slate-500 text-[0.5rem] font-bold uppercase tracking-widest leading-tight">Guest Photo Placeholder</p>


### PR DESCRIPTION
## Summary
This PR fixes the Welcome card's pup photo container in src/templates/index.html to ensure it maintains a fixed, predictable height of 280px regardless of the dimensions of the uploaded photo.

## What Changed
- **Pup Photo Container Height**: Defined a fixed height of 280px for .pup-image-container in CSS.
- **HTML Structure**: Cleaned up flex-1 min-h-0 classes from both the image and the placeholder container divs in src/templates/index.html.
- **Alignment**: Added justify-center to the parent container to vertically center the image container inside the Welcome card.

## Verification
Verification Tier: Tier 1 (Manual verification).
Restarted the Wallboard service locally and verified that the page renders correctly with HTTP 200 OK status.

## References
Ref #54
