### PR TITLE
style: adjust discussion topics spacing and remove justify-between. Ref #56

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -290,11 +290,11 @@
             </div>
 
             <div class="glass rounded-[2rem] p-4 relative overflow-hidden flex-1 border-white/5 min-h-0 shadow-2xl flex flex-col">
-                <h3 class="text-lg font-bold mb-2 flex items-center gap-3 tracking-tight text-white/90">
+                <h3 class="text-lg font-bold mb-5 flex items-center gap-3 tracking-tight text-white/90">
                     <i class="fas fa-comments text-amber-500 text-sm"></i>
                     Discussion Topics
                 </h3>
-                <div class="flex-1 flex flex-col justify-between gap-1">
+                <div class="flex flex-col gap-4">
                     <!-- 1. Daily Routine -->
                     <div class="pb-1">
                         <div class="flex items-center gap-1.5 text-white font-semibold text-base mb-0.5">


### PR DESCRIPTION
## Summary
This PR fixes the Discussion Topics card spacing in src/templates/index.html to remove large uneven gaps between the four sections and increase spacing below the card title.

## What Changed
- **Header Spacing**: Increased the margin below the title from mb-2 to mb-5.
- **Section Spacing**: Removed flex-1 and justify-between from the wrapper and replaced it with a fixed gap-4.

## Verification
Verification Tier: Tier 1 (Manual verification).
Restarted the Wallboard service locally and verified that the page renders correctly with HTTP 200 OK status.

## References
Ref #56
