### PR TITLE
style: Remove dynamic growth from Discussion Topics card wrapper. Ref #62

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -289,7 +289,7 @@
                 </div>
             </div>
 
-            <div class="glass rounded-[2rem] p-4 relative overflow-hidden flex-1 border-white/5 min-h-0 shadow-2xl flex flex-col">
+            <div class="glass rounded-[2rem] p-4 relative overflow-hidden border-white/5 shadow-2xl flex flex-col">
                 <h3 class="text-lg font-bold mb-5 flex items-center gap-3 tracking-tight text-white/90">
                     <i class="fas fa-comments text-amber-500 text-sm"></i>
                     Discussion Topics


### PR DESCRIPTION
## Summary
This PR removes the dynamic growth classes (flex-1 and min-h-0) from the Discussion Topics card wrapper to ensure it sizes itself to its content. This completes the standardization of layout constraints across all cards in the wallboard template.

## What Changed
- `src/templates/index.html`:
  - Removed `flex-1` and `min-h-0` classes from the outer wrapper of the Discussion Topics card.

## Verification
Tier 1: Manual verification. Verified by restarting the FastAPI server locally and requesting the homepage to confirm a 200 OK status code and correct layout rendering.

## References
Ref #62
