### PR TITLE
chore: Add missing httpx dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ anyio==4.13.0
 click==8.3.3
 fastapi==0.136.1
 h11==0.16.0
+httpx==0.28.1
 idna==3.13
 Jinja2==3.1.6
 MarkupSafe==3.0.3


### PR DESCRIPTION
## Summary
This PR adds the missing `httpx` package to the project requirements. `httpx` is imported and used directly in main.py to query weather forecasts from the Open-Meteo API.

## What Changed
- `requirements.txt`: Added `httpx==0.28.1` in alphabetical order.

## Verification
Tier 1: Manual verification. Verified by running `.venv/bin/pip install -r requirements.txt` to confirm a clean installation in the virtual environment. Subsequently restarted the FastAPI server and successfully verified that the homepage compiles and renders with status 200 OK.

## References
Ref #72
