### PR TITLE
feat: Condense Discussion Topics card layout and copy

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -302,8 +302,7 @@
                             <span>Rover & Wag!</span>
                         </div>
                         <ul class="text-slate-400 text-base pl-4 list-disc space-y-0.5">
-                            <li>Morning + walk updates sent to you</li>
-                            <li>Want others looped in? Happy to set up a group text</li>
+                            <li>Morning & walk updates (group texts available)</li>
                             <li>7-day cancellation policy</li>
                         </ul>
                     </div>
@@ -315,9 +314,8 @@
                             <span>Routine</span>
                         </div>
                         <ul class="text-slate-400 text-base pl-4 list-disc space-y-0.5">
-                            <li>Feeding quirks? (toppers, cooked, refrigerated, resource guarding)</li>
-                            <li>Energy level and potty cues?</li>
-                            <li>Self-entertain style? (chew toys, bones)</li>
+                            <li>Feeding quirks (toppers, cooked food, guarding)?</li>
+                            <li>Energy level, potty cues, self-entertaining style?</li>
                         </ul>
                     </div>
 
@@ -328,9 +326,8 @@
                             <span>Out & About</span>
                         </div>
                         <ul class="text-slate-400 text-base pl-4 list-disc space-y-0.5">
-                            <li>Leash behavior, other pups?</li>
-                            <li>Reactions: dogs, strangers, runners, cyclists?</li>
-                            <li>Heat/rain limits: skip over 85°F or heavy rain</li>
+                            <li>Leash behavior and reactions (dogs, strangers, cyclists)?</li>
+                            <li>Weather limits (skip over 85°F or heavy rain)</li>
                         </ul>
                     </div>
 
@@ -341,14 +338,8 @@
                             <span>Personality & Alone Time</span>
                         </div>
                         <ul class="text-slate-400 text-base pl-4 list-disc space-y-0.5">
-                            <li>Spooky triggers? (thunder, fireworks)</li>
-                            <li>Friendly with new people/dogs?</li>
-                            <li>Rover/Wag visits
-                                <ul class="pl-5 list-[circle] space-y-0.5 mt-0.5 text-slate-400/90 text-sm" style="list-style-type: circle;">
-                                    <li>Bella, Eevee/Tina Tues; Luke/Leia Thurs/Sat</li>
-                                    <li>Alone up to 1.5 hrs, crated or free roam?</li>
-                                </ul>
-                            </li>
+                            <li>Triggers (thunder/fireworks) & friendly with new people/dogs?</li>
+                            <li>Rover/Wag visits (Bella/Eevee/Tina Tue; Luke/Leia Thu/Sat) & alone time limits (up to 1.5 hours)?</li>
                         </ul>
                     </div>
 
@@ -359,9 +350,8 @@
                             <span>Bedtime</span>
                         </div>
                         <ul class="text-slate-400 text-base pl-4 list-disc space-y-0.5">
-                            <li>Sleep spots and nightly routine?</li>
-                            <li>Crate comfort, how long?</li>
-                            <li>Bring a scent from home? (blanket, old t-shirt)</li>
+                            <li>Sleep spots, crate comfort, and nightly routine?</li>
+                            <li>Bring comfort items (scent from home, blanket, t-shirt)</li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
This Pull Request condenses the Discussion Topics card layout on the Wallboard dashboard. It merges related list items to reduce the overall bullet count from 17 down to 10 flat bullets, removing nested list structures to significantly reduce the card's vertical height.

## What Changed
- **src/templates/index.html**: Rolled related bullet points together for each section of the Discussion Topics card (Rover & Wag!, Routine, Out & About, Personality & Alone Time, Bedtime) to limit each section to exactly 2 flat bullets.

## Verification
- Checked locally that the server runs correctly and returns 200 OK.
- Applied Tier 1 verification: Manual check of the modified HTML layout.

## References
Ref #75
